### PR TITLE
Using ROS 2 dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(xbot2_interface
     PUBLIC
     ${urdf_LIBRARIES}
     ${srdfdom_LIBRARIES}
+    srdfdom::srdfdom
     Eigen3::Eigen)
 
 target_compile_options(xbot2_interface
@@ -106,7 +107,7 @@ if(${XBOT2_IFC_BUILD_COLLISION})
     add_subdirectory(src/collision/)
 endif()
 
-#add_subdirectory(python)
+add_subdirectory(python)
 
 #add_subdirectory(examples)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ option(XBOT2_IFC_BUILD_TESTS "Build tests" OFF)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(ROS_DISTRO $ENV{ROS_DISTRO} )
+set(SRDFDOM_INCLUDE_DIR /opt/ros/${ROS_DISTRO}/include)
 set(CMAKE_INSTALL_RPATH $ORIGIN)
 set(CMAKE_BUILD_RPATH "$ORIGIN;$ORIGIN/pinocchio;$ORIGIN/rbdl;$ORIGIN/ros")
 
@@ -63,6 +65,7 @@ target_compile_definitions(xbot2_interface
 
 target_include_directories(xbot2_interface
     PUBLIC
+    ${SRDFDOM_INCLUDE_DIR}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
@@ -96,16 +99,16 @@ if(${XBOT2_IFC_BUILD_RBDL})
 endif()
 
 if(${XBOT2_IFC_BUILD_ROS})
-    add_subdirectory(ros/)
+    #add_subdirectory(ros/)
 endif()
 
 if(${XBOT2_IFC_BUILD_COLLISION})
     add_subdirectory(src/collision/)
 endif()
 
-add_subdirectory(python)
+#add_subdirectory(python)
 
-add_subdirectory(examples)
+#add_subdirectory(examples)
 
 if(${XBOT2_IFC_BUILD_TESTS})
 	enable_testing()

--- a/cmake/ExportProject.cmake
+++ b/cmake/ExportProject.cmake
@@ -45,4 +45,16 @@ function(export_project)
         DESTINATION lib/cmake/${PROJECT_NAME}
         )
 
+    ## Packaging
+    set(CPACK_PACKAGE_VENDOR "Gauss Robotics GmbH")
+    set(CPACK_GENERATOR "DEB;TGZ")
+    set(CPACK_PACKAGE_VERSION 1.0.0)
+    set(CPACK_SYSTEM_NAME ${CMAKE_HOST_SYSTEM_PROCESSOR})
+
+    # Debian versions require a dash
+    set(CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION}-1)
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Gauss Robotics GmbH")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libboost-all-dev, ros-${ROS_DISTRO}-srdfdom, ros-${ROS_DISTRO}-pinocchio, ros-${ROS_DISTRO}-tf2-eigen-kdl, ros-${ROS_DISTRO}-hpp-fcl, ros-${ROS_DISTRO}-geometric-shapes, ros-${ROS_DISTRO}-moveit-core")
+    include(CPack)
+
 endfunction()

--- a/include/xbot2_interface/xbotinterface2.h
+++ b/include/xbot2_interface/xbotinterface2.h
@@ -5,6 +5,10 @@
 #include <urdf_model/model.h>
 #include <srdfdom/model.h>
 
+#include <iostream>
+#include <list>
+#include <set>
+
 #include "chain.h"
 #include "joint.h"
 #include "imu.h"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -9,11 +9,7 @@ if(${pybind11_FOUND} AND ${COMPILE_PYTHON_BINDINGS})
     message(STATUS "Found python (${Python3_EXECUTABLE}) will compile python bindings")
 
     # get python install path
-    execute_process(
-        COMMAND ${Python3_EXECUTABLE} -c "import site, os; print(os.path.relpath(site.USER_SITE, site.USER_BASE))"
-        OUTPUT_VARIABLE PYTHON_SITE
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
+    set(PYTHON_SITE "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/dist-packages")
     message(STATUS "Python install dir: ${PYTHON_SITE}")
 
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
With this PR you can compile xbot2_interface with ROS 2 dependencies.

Install instructions:

```bash
sudo apt install -y libboost-all-dev ros-humble-srdfdom ros-humble-pinocchio ros-humble-tf2-eigen-kdl ros-humble-hpp-fcl ros-humble-geometric-shapes ros-humble-moveit-core

mkdir build
cd build
source /opt/ros/humble/setup.bash
cmake .. -DCMAKE_BUILD_TYPE=Release 
make -j16
cpack -G DEB
sudo dpkg -i *.deb
```