### PR TITLE
Add interface methods to get twists and jacobians in WORLD

### DIFF
--- a/include/xbot2_interface/xbotinterface2.h
+++ b/include/xbot2_interface/xbotinterface2.h
@@ -210,6 +210,8 @@ public:
     // absolute
     virtual void getJacobian(int link_id,
                              MatRef J) const = 0;
+    virtual void getJacobianInWorld(int link_id,
+                             MatRef J) const = 0;
 
     bool getJacobian(string_const_ref link_name,
                      MatRef J) const;
@@ -226,6 +228,7 @@ public:
                      Eigen::MatrixXd& J) const;
 
     Eigen::MatrixXd getJacobian(string_const_ref link_name) const;
+    Eigen::MatrixXd getJacobianInWorld(string_const_ref link_name) const;
 
     // relative
     virtual void getRelativeJacobian(int distal_id,
@@ -271,12 +274,16 @@ public:
                         Eigen::Affine3d& b_R_l) const;
 
     // velocity twist (absolute)
-    virtual Eigen::Vector6d getVelocityTwist(int link_id) const;
-
     Eigen::Vector6d getVelocityTwist(string_const_ref link_name) const;
+
+    virtual Eigen::Vector6d getVelocityTwist(int link_id) const;
 
     bool getVelocityTwist(string_const_ref link_name,
                           Eigen::Vector6d& v) const;
+
+    // velocity twist (absolute) in global
+    Eigen::Vector6d getVelocityTwistInWorld(string_const_ref link_name) const;
+    virtual Eigen::Vector6d getVelocityTwistInWorld(int link_id) const = 0;
 
     // acceleration twist (absolute)
     virtual Eigen::Vector6d getAccelerationTwist(int link_id) const;
@@ -285,6 +292,10 @@ public:
 
     bool getAccelerationTwist(string_const_ref link_name,
                               Eigen::Vector6d& a) const;
+
+    // acceleration twist (absolute) in global
+    Eigen::Vector6d getAccelerationTwistInWorld(string_const_ref link_name) const;
+    virtual Eigen::Vector6d getAccelerationTwistInWorld(int link_id) const = 0;
 
     //
     virtual Eigen::Vector6d getJdotTimesV(int link_id) const;

--- a/pinocchio/modelinterface2_pin.cpp
+++ b/pinocchio/modelinterface2_pin.cpp
@@ -390,9 +390,7 @@ Eigen::Vector6d XBot::ModelInterface2Pin::getVelocityTwistInWorld(int frame_idx)
 {
     check_frame_idx_throw(frame_idx);
 
-    auto v = pinocchio::getFrameVelocity(_mdl, _data, frame_idx, pinocchio::ReferenceFrame::WORLD);
-
-    return v;
+    return pinocchio::getFrameVelocity(_mdl, _data, frame_idx, pinocchio::ReferenceFrame::WORLD);
 }
 
 Eigen::Vector6d ModelInterface2Pin::getAccelerationTwist(int frame_idx) const
@@ -406,9 +404,7 @@ Eigen::Vector6d XBot::ModelInterface2Pin::getAccelerationTwistInWorld(int frame_
 {
     check_frame_idx_throw(frame_idx);
 
-    auto v = pinocchio::getFrameClassicalAcceleration(_mdl, _data, frame_idx, pinocchio::ReferenceFrame::WORLD);
-
-    return v;
+    return pinocchio::getFrameClassicalAcceleration(_mdl, _data, frame_idx, pinocchio::ReferenceFrame::WORLD);
 }
 
 Eigen::Vector6d ModelInterface2Pin::getJdotTimesV(int frame_idx) const

--- a/pinocchio/modelinterface2_pin.cpp
+++ b/pinocchio/modelinterface2_pin.cpp
@@ -115,6 +115,21 @@ void ModelInterface2Pin::getJacobian(int link_id, MatRef J) const
     pinocchio::getFrameJacobian(_mdl, _data, link_id, _world_aligned, J);
 }
 
+void ModelInterface2Pin::getJacobianInWorld(int link_id, MatRef J) const
+{
+    check_frame_idx_throw(link_id);
+
+    if(!(_cached_computation & Jacobians))
+    {
+        pinocchio::computeJointJacobians(_mdl, _data, getJointPosition());
+        _cached_computation |= Jacobians;
+    }
+
+    J.setZero();
+
+    pinocchio::getFrameJacobian(_mdl, _data, link_id, pinocchio::ReferenceFrame::WORLD, J);
+}
+
 
 MatConstRef ModelInterface2Pin::computeRegressor() const
 {
@@ -371,11 +386,29 @@ Eigen::Vector6d XBot::ModelInterface2Pin::getVelocityTwist(int frame_idx) const
     return v;
 }
 
+Eigen::Vector6d XBot::ModelInterface2Pin::getVelocityTwistInWorld(int frame_idx) const
+{
+    check_frame_idx_throw(frame_idx);
+
+    auto v = pinocchio::getFrameVelocity(_mdl, _data, frame_idx, pinocchio::ReferenceFrame::WORLD);
+
+    return v;
+}
+
 Eigen::Vector6d ModelInterface2Pin::getAccelerationTwist(int frame_idx) const
 {
     check_frame_idx_throw(frame_idx);
 
     return pinocchio::getFrameClassicalAcceleration(_mdl, _data, frame_idx, _world_aligned);
+}
+
+Eigen::Vector6d XBot::ModelInterface2Pin::getAccelerationTwistInWorld(int frame_idx) const
+{
+    check_frame_idx_throw(frame_idx);
+
+    auto v = pinocchio::getFrameClassicalAcceleration(_mdl, _data, frame_idx, pinocchio::ReferenceFrame::WORLD);
+
+    return v;
 }
 
 Eigen::Vector6d ModelInterface2Pin::getJdotTimesV(int frame_idx) const

--- a/pinocchio/modelinterface2_pin.h
+++ b/pinocchio/modelinterface2_pin.h
@@ -26,10 +26,13 @@ public:
     Eigen::Affine3d getPose(int link_id) const override;
 
     void getJacobian(int link_id, MatRef J) const override;
+    void getJacobianInWorld(int link_id, MatRef J) const override;
 
     Eigen::Vector6d getVelocityTwist(int link_id) const override;
+    Eigen::Vector6d getVelocityTwistInWorld(int link_id) const override;
 
     Eigen::Vector6d getAccelerationTwist(int link_id) const override;
+    Eigen::Vector6d getAccelerationTwistInWorld(int link_id) const override;
 
     Eigen::Vector6d getJdotTimesV(int link_id) const override;
 

--- a/python/pyxbot2_interface.cpp
+++ b/python/pyxbot2_interface.cpp
@@ -153,8 +153,12 @@ PYBIND11_MODULE(pyxbot2_interface, m) {
              py::overload_cast<string_const_ref, string_const_ref>(&XBotInterface::getPose, py::const_))
         .def("getAccelerationTwist",
              py::overload_cast<string_const_ref>(&XBotInterface::getAccelerationTwist, py::const_))
+        .def("getAccelerationTwistInWorld",
+             py::overload_cast<string_const_ref>(&XBotInterface::getAccelerationTwistInWorld, py::const_))
         .def("getVelocityTwist",
              py::overload_cast<string_const_ref>(&XBotInterface::getVelocityTwist, py::const_))
+        .def("getVelocityTwistInWorld",
+             py::overload_cast<string_const_ref>(&XBotInterface::getVelocityTwistInWorld, py::const_))
         .def("getJdotTimesV",
              py::overload_cast<string_const_ref>(&XBotInterface::getJdotTimesV, py::const_))
         .def("getCOM",
@@ -169,6 +173,8 @@ PYBIND11_MODULE(pyxbot2_interface, m) {
              py::overload_cast<string_const_ref, string_const_ref>(&XBotInterface::getRelativeJdotTimesV, py::const_))
         .def("getJacobian",
              py::overload_cast<string_const_ref>(&XBotInterface::getJacobian, py::const_))
+        .def("getJacobianInWorld",
+             py::overload_cast<string_const_ref>(&XBotInterface::getJacobianInWorld, py::const_))
         .def("getRelativeJacobian",
              py::overload_cast<string_const_ref, string_const_ref>(&XBotInterface::getRelativeJacobian, py::const_))
         .def("computeInverseDynamics",
@@ -277,6 +283,8 @@ PYBIND11_MODULE(pyxbot2_interface, m) {
                       py::overload_cast<VecConstRef>(&ModelInterface::setJointEffort))
         .def("getInverseJacobian",
              [](const ModelInterface& self, const std::string& link_id) { return pinv_SVD(self.getJacobian(link_id)); })
+        .def("getInverseJacobianInWorld",
+             [](const ModelInterface& self, const std::string& link_id) { return pinv_SVD(self.getJacobianInWorld(link_id)); })
         ;
 
     py::class_<RobotInterface, XBotInterface, RobotInterface::Ptr>(m, "RobotInterface2")

--- a/src/xbotinterface2.cpp
+++ b/src/xbotinterface2.cpp
@@ -1078,6 +1078,19 @@ Eigen::MatrixXd XBotInterface::getJacobian(string_const_ref link_name) const
     return J;
 }
 
+Eigen::MatrixXd XBotInterface::getJacobianInWorld(string_const_ref link_name) const
+{
+    Eigen::MatrixXd J;
+
+    J.setZero(6, getNv());
+
+    int idx = impl->get_link_id_throw(link_name);
+
+    getJacobianInWorld(idx, J);
+
+    return J;
+}
+
 
 void XBotInterface::getRelativeJacobian(int distal_id, int base_id, MatRef Jrel) const
 {
@@ -1247,6 +1260,11 @@ Eigen::Vector6d XBotInterface::getVelocityTwist(string_const_ref link_name) cons
     return getVelocityTwist(impl->get_link_id_throw(link_name));
 }
 
+Eigen::Vector6d XBotInterface::getVelocityTwistInWorld(string_const_ref link_name) const
+{
+    return getVelocityTwistInWorld(impl->get_link_id_throw(link_name));
+}
+
 bool XBotInterface::getVelocityTwist(string_const_ref link_name, Eigen::Vector6d &v) const
 {
     int idx = impl->get_link_id_error(link_name);
@@ -1272,6 +1290,11 @@ Eigen::Vector6d XBotInterface::getAccelerationTwist(int link_id) const
 Eigen::Vector6d XBotInterface::getAccelerationTwist(string_const_ref link_name) const
 {
     return getAccelerationTwist(impl->get_link_id_throw(link_name));
+}
+
+Eigen::Vector6d XBotInterface::getAccelerationTwistInWorld(string_const_ref link_name) const
+{
+    return getAccelerationTwistInWorld(impl->get_link_id_throw(link_name));
 }
 
 bool XBotInterface::getAccelerationTwist(string_const_ref link_name, Eigen::Vector6d &v) const


### PR DESCRIPTION
In order to work with quant in prims and not have to do too much computations post mortem, this PR adds interface methods for python to get velocity, acceleration and jacobians in the WORLD reference system. See also https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/group__pinocchio__multibody.html