### PR TITLE
Fix RPath of python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(xbot2_interface LANGUAGES CXX VERSION 1.1.0)
+project(xbot2_interface LANGUAGES CXX VERSION 1.1.1)
 
 option(XBOT2_IFC_BUILD_PINOCCHIO "Build Pinocchio implementation" ON)
 option(XBOT2_IFC_BUILD_RBDL "Build RBDL implementation" OFF)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,6 +29,8 @@ if(${pybind11_FOUND} AND ${COMPILE_PYTHON_BINDINGS})
 
     target_link_libraries(pyxbot2_interface PUBLIC xbot2_interface)
 
+    set_target_properties(pyxbot2_interface PROPERTIES INSTALL_RPATH "$ORIGIN/../../..")
+
     install(TARGETS pyxbot2_interface
         DESTINATION ${PYTHON_SITE}/xbot2_interface)
 
@@ -36,6 +38,8 @@ if(${pybind11_FOUND} AND ${COMPILE_PYTHON_BINDINGS})
     pybind11_add_module(pyaffine3 pyaffine3.cpp)
 
     target_link_libraries(pyaffine3 PUBLIC Eigen3::Eigen)
+    
+    set_target_properties(pyaffine3 PROPERTIES INSTALL_RPATH "$ORIGIN/../../..")
 
     install(TARGETS pyaffine3
         DESTINATION ${PYTHON_SITE}/xbot2_interface)
@@ -44,6 +48,8 @@ if(${pybind11_FOUND} AND ${COMPILE_PYTHON_BINDINGS})
         pybind11_add_module(pyxbot2_collision pyxbot2_collision.cpp)
 
         target_link_libraries(pyxbot2_collision PUBLIC xbot2_interface::collision)
+        
+        set_target_properties(pyxbot2_collision PROPERTIES INSTALL_RPATH "$ORIGIN/../../..")
 
         install(TARGETS pyxbot2_collision
             DESTINATION ${PYTHON_SITE}/xbot2_interface)


### PR DESCRIPTION
Set Rpathes.

The python so have a path two the grandgrandparentdirectory as there are the origin libraries the bindings are binding to.