### PR TITLE
Feature/configure logger

### DIFF
--- a/python/pyxbot2_interface.cpp
+++ b/python/pyxbot2_interface.cpp
@@ -417,3 +417,6 @@ PYBIND11_MODULE(pyxbot2_interface, m) {
     py::class_<ModelJoint, Joint, ModelJoint::Ptr>(m, "ModelJoint", py::multiple_inheritance());
 
     py::class_<RobotJoint, Joint, RobotJoint::Ptr>(m, "RobotJoint", py::multiple_inheritance());
+
+}
+

--- a/python/pyxbot2_interface.cpp
+++ b/python/pyxbot2_interface.cpp
@@ -1,4 +1,5 @@
 #include <xbot2_interface/robotinterface2.h>
+#include <xbot2_interface/logger.h>
 #include <xbot2_interface/common/utils.h>
 
 #include <pybind11/pybind11.h>
@@ -408,8 +409,11 @@ PYBIND11_MODULE(pyxbot2_interface, m) {
         .def("getChildLink", &Joint::getChildLink)
         ;
 
+    py::class_<Logger, std::shared_ptr<Logger>>(m, "Logger")
+        .def_static("set_verbosity_level_to_fatal", [](){ Logger::SetVerbosityLevel(Logger::Severity::FATAL); })
+        .def_static("set_verbosity_level_to_low", [](){ Logger::SetVerbosityLevel(Logger::Severity::LOW); })
+        ;
+
     py::class_<ModelJoint, Joint, ModelJoint::Ptr>(m, "ModelJoint", py::multiple_inheritance());
 
     py::class_<RobotJoint, Joint, RobotJoint::Ptr>(m, "RobotJoint", py::multiple_inheritance());
-
-}

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -181,7 +181,7 @@ void LoggerClass::DefaultOnPrint(char *msg, int n_chars, Logger::Severity s)
 LoggerClass::LoggerClass(std::string name)
     : _endl(*this)
     , _name(name)
-    , _verbosity_level(Logger::Severity::LOW)
+    , _verbosity_level(Logger::Severity::FATAL)
     , _severity(Logger::Severity::LOW)
     , _on_print(&LoggerClass::DefaultOnPrint)
 {


### PR DESCRIPTION
Simple API to enable (`set_verbosity_level_to_low`) or disable (`set_verbosity_level_to_fatal`) the OpenSoT/XBot Logger.
This changes primarily the level in a simplified way (we don't need to create pybindings for SeverityLevel). The **fatal** level seems to be unused and as such nothing will be print...